### PR TITLE
Feature/fixed blocker

### DIFF
--- a/http/blocker.http
+++ b/http/blocker.http
@@ -3,5 +3,8 @@ POST localhost:8080/blocker
 Content-Type: application/json
 
 {
-  "extension": "exe"
+  "extension": "jpg"
 }
+
+### 확장자 차단기 전체 조회
+GET localhost:8080/blocker

--- a/http/blocker.http
+++ b/http/blocker.http
@@ -3,8 +3,11 @@ POST localhost:8080/blocker
 Content-Type: application/json
 
 {
-  "extension": "jpg"
+  "extension": "exe"
 }
 
 ### 확장자 차단기 전체 조회
 GET localhost:8080/blocker
+
+### 확장자 차단기 삭제
+PATCH localhost:8080/blocker/exe

--- a/http/blocker.http
+++ b/http/blocker.http
@@ -3,7 +3,8 @@ POST localhost:8080/blockers
 Content-Type: application/json
 
 {
-  "extension": "exe"
+  "extension": "exe",
+  "type": "CUSTOM"
 }
 
 ### 확장자 차단기 전체 조회

--- a/http/blocker.http
+++ b/http/blocker.http
@@ -1,5 +1,5 @@
 ### 확장자 차단기 단 건 등록
-POST localhost:8080/blocker
+POST localhost:8080/blockers
 Content-Type: application/json
 
 {
@@ -7,7 +7,7 @@ Content-Type: application/json
 }
 
 ### 확장자 차단기 전체 조회
-GET localhost:8080/blocker
+GET localhost:8080/blockers
 
 ### 확장자 차단기 삭제
-PATCH localhost:8080/blocker/exe
+PATCH localhost:8080/blockers/exe

--- a/http/blocker.http
+++ b/http/blocker.http
@@ -1,0 +1,7 @@
+### 확장자 차단기 단 건 등록
+POST localhost:8080/blocker
+Content-Type: application/json
+
+{
+  "extension": "exe"
+}

--- a/src/main/java/flow/extensionblocker/ExtensionBlockerApplication.java
+++ b/src/main/java/flow/extensionblocker/ExtensionBlockerApplication.java
@@ -2,7 +2,9 @@ package flow.extensionblocker;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class ExtensionBlockerApplication {
 

--- a/src/main/java/flow/extensionblocker/application/BlockerService.java
+++ b/src/main/java/flow/extensionblocker/application/BlockerService.java
@@ -7,6 +7,7 @@ import flow.extensionblocker.domain.Blocker;
 import flow.extensionblocker.domain.BlockerRepository;
 import jakarta.transaction.Transactional;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -18,6 +19,11 @@ public class BlockerService {
 
   @Transactional
   public CreateBlockerResponse createBlocker(CreateBlockerRequest request) {
+    Optional<Blocker> checkedBlocker = isBlockerExists(request.extension());
+    if (checkedBlocker.isPresent()) {
+      return CreateBlockerResponse.from(checkedBlocker.get().restore());
+    }
+
     Blocker blocker = blockerRepository.createBlocker(CreateBlockerRequest.toBlocker(request));
     return CreateBlockerResponse.from(blocker);
   }
@@ -28,11 +34,6 @@ public class BlockerService {
         .toList();
   }
 
-  private Blocker findBlocker(String extension) {
-    return blockerRepository.findBlocker(extension)
-        .orElseThrow(() -> new IllegalArgumentException("임시용 예외: " + extension + " 는 없음"));
-  }
-
   @Transactional
   public void deleteBlocker(String extension) {
     Blocker blocker = this.findBlocker(extension);
@@ -41,5 +42,14 @@ public class BlockerService {
     }
 
     blocker.delete();
+  }
+
+  private Optional<Blocker> isBlockerExists(String extension) {
+    return blockerRepository.findBlocker(extension);
+  }
+
+  private Blocker findBlocker(String extension) {
+    return blockerRepository.findBlocker(extension)
+        .orElseThrow(() -> new IllegalArgumentException("임시용 예외: " + extension + " 는 없음"));
   }
 }

--- a/src/main/java/flow/extensionblocker/application/BlockerService.java
+++ b/src/main/java/flow/extensionblocker/application/BlockerService.java
@@ -20,7 +20,7 @@ public class BlockerService {
     return CreateBlockerResponse.from(blocker);
   }
 
-  public List<BlockerResponse> getBlockers(String extension) {
+  public List<BlockerResponse> getBlockers() {
     return blockerRepository.findBlockers().stream()
         .map(BlockerResponse::from)
         .toList();

--- a/src/main/java/flow/extensionblocker/application/BlockerService.java
+++ b/src/main/java/flow/extensionblocker/application/BlockerService.java
@@ -1,0 +1,19 @@
+package flow.extensionblocker.application;
+
+import flow.extensionblocker.domain.Blocker;
+import flow.extensionblocker.domain.BlockerRepository;
+import flow.extensionblocker.application.dto.CreateBlockerResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class BlockerService {
+
+  private final BlockerRepository blockerRepository;
+
+  public CreateBlockerResponse createBlocker(String extension) {
+    Blocker blocker = blockerRepository.createBlocker(Blocker.of(extension));
+    return CreateBlockerResponse.from(blocker);
+  }
+}

--- a/src/main/java/flow/extensionblocker/application/BlockerService.java
+++ b/src/main/java/flow/extensionblocker/application/BlockerService.java
@@ -1,9 +1,10 @@
 package flow.extensionblocker.application;
 
+import flow.extensionblocker.application.dto.BlockerResponse;
 import flow.extensionblocker.application.dto.CreateBlockerRequest;
+import flow.extensionblocker.application.dto.CreateBlockerResponse;
 import flow.extensionblocker.domain.Blocker;
 import flow.extensionblocker.domain.BlockerRepository;
-import flow.extensionblocker.application.dto.CreateBlockerResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -16,5 +17,15 @@ public class BlockerService {
   public CreateBlockerResponse createBlocker(CreateBlockerRequest request) {
     Blocker blocker = blockerRepository.createBlocker(CreateBlockerRequest.toBlocker(request));
     return CreateBlockerResponse.from(blocker);
+  }
+
+  public BlockerResponse getBlocker(String extension) {
+    Blocker blocker = this.findBlocker(extension);
+    return BlockerResponse.from(blocker);
+  }
+
+  private Blocker findBlocker(String extension) {
+    return blockerRepository.findBlocker(extension)
+        .orElseThrow(() -> new IllegalArgumentException("임시용 예외: " + extension + " 는 없음"));
   }
 }

--- a/src/main/java/flow/extensionblocker/application/BlockerService.java
+++ b/src/main/java/flow/extensionblocker/application/BlockerService.java
@@ -5,6 +5,7 @@ import flow.extensionblocker.application.dto.CreateBlockerRequest;
 import flow.extensionblocker.application.dto.CreateBlockerResponse;
 import flow.extensionblocker.domain.Blocker;
 import flow.extensionblocker.domain.BlockerRepository;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -19,9 +20,10 @@ public class BlockerService {
     return CreateBlockerResponse.from(blocker);
   }
 
-  public BlockerResponse getBlocker(String extension) {
-    Blocker blocker = this.findBlocker(extension);
-    return BlockerResponse.from(blocker);
+  public List<BlockerResponse> getBlockers(String extension) {
+    return blockerRepository.findBlockers().stream()
+        .map(BlockerResponse::from)
+        .toList();
   }
 
   private Blocker findBlocker(String extension) {

--- a/src/main/java/flow/extensionblocker/application/BlockerService.java
+++ b/src/main/java/flow/extensionblocker/application/BlockerService.java
@@ -52,4 +52,8 @@ public class BlockerService {
     return blockerRepository.findBlocker(extension)
         .orElseThrow(() -> new IllegalArgumentException("임시용 예외: " + extension + " 는 없음"));
   }
+
+  public boolean isBlocked(String extension) {
+    return blockerRepository.findBlockerNotDeleted(extension).isPresent();
+  }
 }

--- a/src/main/java/flow/extensionblocker/application/BlockerService.java
+++ b/src/main/java/flow/extensionblocker/application/BlockerService.java
@@ -5,6 +5,7 @@ import flow.extensionblocker.application.dto.CreateBlockerRequest;
 import flow.extensionblocker.application.dto.CreateBlockerResponse;
 import flow.extensionblocker.domain.Blocker;
 import flow.extensionblocker.domain.BlockerRepository;
+import jakarta.transaction.Transactional;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -15,6 +16,7 @@ public class BlockerService {
 
   private final BlockerRepository blockerRepository;
 
+  @Transactional
   public CreateBlockerResponse createBlocker(CreateBlockerRequest request) {
     Blocker blocker = blockerRepository.createBlocker(CreateBlockerRequest.toBlocker(request));
     return CreateBlockerResponse.from(blocker);
@@ -31,6 +33,7 @@ public class BlockerService {
         .orElseThrow(() -> new IllegalArgumentException("임시용 예외: " + extension + " 는 없음"));
   }
 
+  @Transactional
   public void deleteBlocker(String extension) {
     Blocker blocker = this.findBlocker(extension);
     if (blocker.getDeletedAt() != null) {

--- a/src/main/java/flow/extensionblocker/application/BlockerService.java
+++ b/src/main/java/flow/extensionblocker/application/BlockerService.java
@@ -1,5 +1,6 @@
 package flow.extensionblocker.application;
 
+import flow.extensionblocker.application.dto.CreateBlockerRequest;
 import flow.extensionblocker.domain.Blocker;
 import flow.extensionblocker.domain.BlockerRepository;
 import flow.extensionblocker.application.dto.CreateBlockerResponse;
@@ -12,8 +13,8 @@ public class BlockerService {
 
   private final BlockerRepository blockerRepository;
 
-  public CreateBlockerResponse createBlocker(String extension) {
-    Blocker blocker = blockerRepository.createBlocker(Blocker.of(extension));
+  public CreateBlockerResponse createBlocker(CreateBlockerRequest request) {
+    Blocker blocker = blockerRepository.createBlocker(CreateBlockerRequest.toBlocker(request));
     return CreateBlockerResponse.from(blocker);
   }
 }

--- a/src/main/java/flow/extensionblocker/application/BlockerService.java
+++ b/src/main/java/flow/extensionblocker/application/BlockerService.java
@@ -37,8 +37,8 @@ public class BlockerService {
   @Transactional
   public void deleteBlocker(String extension) {
     Blocker blocker = this.findBlocker(extension);
-    if (blocker.getDeletedAt() != null) {
-      throw new IllegalArgumentException("임시용 예외: " + extension + " 는 이미 삭제됨");
+    if (!blocker.isEnabled() && blocker.getDeletedAt() != null) {
+      throw new IllegalArgumentException(extension + " 는 이미 삭제됨");
     }
 
     blocker.delete();
@@ -50,7 +50,7 @@ public class BlockerService {
 
   private Blocker findBlocker(String extension) {
     return blockerRepository.findBlocker(extension)
-        .orElseThrow(() -> new IllegalArgumentException("임시용 예외: " + extension + " 는 없음"));
+        .orElseThrow(() -> new IllegalArgumentException(extension + " 가 없음"));
   }
 
   public boolean isBlocked(String extension) {

--- a/src/main/java/flow/extensionblocker/application/BlockerService.java
+++ b/src/main/java/flow/extensionblocker/application/BlockerService.java
@@ -30,4 +30,13 @@ public class BlockerService {
     return blockerRepository.findBlocker(extension)
         .orElseThrow(() -> new IllegalArgumentException("임시용 예외: " + extension + " 는 없음"));
   }
+
+  public void deleteBlocker(String extension) {
+    Blocker blocker = this.findBlocker(extension);
+    if (blocker.getDeletedAt() != null) {
+      throw new IllegalArgumentException("임시용 예외: " + extension + " 는 이미 삭제됨");
+    }
+
+    blocker.delete();
+  }
 }

--- a/src/main/java/flow/extensionblocker/application/dto/BlockerResponse.java
+++ b/src/main/java/flow/extensionblocker/application/dto/BlockerResponse.java
@@ -1,0 +1,11 @@
+package flow.extensionblocker.application.dto;
+
+import flow.extensionblocker.domain.Blocker;
+
+public record BlockerResponse(
+    String extension
+) {
+  public static BlockerResponse from(Blocker blocker) {
+    return new BlockerResponse(blocker.getExtension());
+  }
+}

--- a/src/main/java/flow/extensionblocker/application/dto/BlockerResponse.java
+++ b/src/main/java/flow/extensionblocker/application/dto/BlockerResponse.java
@@ -1,11 +1,13 @@
 package flow.extensionblocker.application.dto;
 
 import flow.extensionblocker.domain.Blocker;
+import flow.extensionblocker.domain.Type;
 
 public record BlockerResponse(
-    String extension
+    String extension,
+    Type type
 ) {
   public static BlockerResponse from(Blocker blocker) {
-    return new BlockerResponse(blocker.getExtension());
+    return new BlockerResponse(blocker.getExtension(), blocker.getType());
   }
 }

--- a/src/main/java/flow/extensionblocker/application/dto/CreateBlockerRequest.java
+++ b/src/main/java/flow/extensionblocker/application/dto/CreateBlockerRequest.java
@@ -2,11 +2,13 @@ package flow.extensionblocker.application.dto;
 
 import flow.extensionblocker.common.annotation.ValidExtension;
 import flow.extensionblocker.domain.Blocker;
+import flow.extensionblocker.domain.Type;
 
 public record CreateBlockerRequest(
-    @ValidExtension String extension
+    @ValidExtension String extension,
+    Type type
 ) {
   public static Blocker toBlocker(CreateBlockerRequest request) {
-    return Blocker.of(request.extension());
+    return Blocker.of(request.extension(), request.type());
   }
 }

--- a/src/main/java/flow/extensionblocker/application/dto/CreateBlockerRequest.java
+++ b/src/main/java/flow/extensionblocker/application/dto/CreateBlockerRequest.java
@@ -1,0 +1,12 @@
+package flow.extensionblocker.application.dto;
+
+import flow.extensionblocker.common.annotation.ValidExtension;
+import flow.extensionblocker.domain.Blocker;
+
+public record CreateBlockerRequest(
+    @ValidExtension String extension
+) {
+  public static Blocker toBlocker(CreateBlockerRequest request) {
+    return Blocker.of(request.extension());
+  }
+}

--- a/src/main/java/flow/extensionblocker/application/dto/CreateBlockerResponse.java
+++ b/src/main/java/flow/extensionblocker/application/dto/CreateBlockerResponse.java
@@ -1,0 +1,11 @@
+package flow.extensionblocker.application.dto;
+
+import flow.extensionblocker.domain.Blocker;
+
+public record CreateBlockerResponse(
+    String extension
+) {
+  public static CreateBlockerResponse from(Blocker blocker) {
+    return new CreateBlockerResponse(blocker.getExtension());
+  }
+}

--- a/src/main/java/flow/extensionblocker/application/dto/CreateBlockerResponse.java
+++ b/src/main/java/flow/extensionblocker/application/dto/CreateBlockerResponse.java
@@ -1,11 +1,13 @@
 package flow.extensionblocker.application.dto;
 
 import flow.extensionblocker.domain.Blocker;
+import flow.extensionblocker.domain.Type;
 
 public record CreateBlockerResponse(
-    String extension
+    String extension,
+    Type type
 ) {
   public static CreateBlockerResponse from(Blocker blocker) {
-    return new CreateBlockerResponse(blocker.getExtension());
+    return new CreateBlockerResponse(blocker.getExtension(), blocker.getType());
   }
 }

--- a/src/main/java/flow/extensionblocker/common/annotation/ValidExtension.java
+++ b/src/main/java/flow/extensionblocker/common/annotation/ValidExtension.java
@@ -12,7 +12,7 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Constraint(validatedBy = ExtensionValidator.class)
 public @interface ValidExtension {
-  String message() default "확장자는 1자 이상 10자 이하의 영문 대소문자와 숫자로만 구성되어야 합니다.";
+  String message() default "확장자는 1자 이상 20자 이하의 영문 대소문자와 숫자로만 구성되어야 합니다.";
   Class<?>[] groups() default {};
   Class<? extends Payload>[] payload() default {};
 }

--- a/src/main/java/flow/extensionblocker/common/annotation/ValidExtension.java
+++ b/src/main/java/flow/extensionblocker/common/annotation/ValidExtension.java
@@ -1,0 +1,18 @@
+package flow.extensionblocker.common.annotation;
+
+import flow.extensionblocker.common.validation.ExtensionValidator;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.FIELD, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = ExtensionValidator.class)
+public @interface ValidExtension {
+  String message() default "확장자는 1자 이상 10자 이하의 영문 대소문자와 숫자로만 구성되어야 합니다.";
+  Class<?>[] groups() default {};
+  Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/flow/extensionblocker/common/validation/ExtensionValidator.java
+++ b/src/main/java/flow/extensionblocker/common/validation/ExtensionValidator.java
@@ -7,7 +7,7 @@ import java.util.regex.Pattern;
 
 public class ExtensionValidator implements ConstraintValidator<ValidExtension, String> {
 
-  private static final java.util.regex.Pattern PATTERN = Pattern.compile("^[a-zA-Z0-9]{1,10}$");
+  private static final java.util.regex.Pattern PATTERN = Pattern.compile("^[a-zA-Z0-9]{1,20}$");
 
   @Override
   public boolean isValid(String extension, ConstraintValidatorContext constraintValidatorContext) {

--- a/src/main/java/flow/extensionblocker/common/validation/ExtensionValidator.java
+++ b/src/main/java/flow/extensionblocker/common/validation/ExtensionValidator.java
@@ -1,0 +1,20 @@
+package flow.extensionblocker.common.validation;
+
+import flow.extensionblocker.common.annotation.ValidExtension;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import java.util.regex.Pattern;
+
+public class ExtensionValidator implements ConstraintValidator<ValidExtension, String> {
+
+  private static final java.util.regex.Pattern PATTERN = Pattern.compile("^[a-zA-Z0-9]{1,10}$");
+
+  @Override
+  public boolean isValid(String extension, ConstraintValidatorContext constraintValidatorContext) {
+    if (extension == null || extension.isBlank()) {
+      return false;
+    }
+
+    return PATTERN.matcher(extension).matches();
+  }
+}

--- a/src/main/java/flow/extensionblocker/domain/Blocker.java
+++ b/src/main/java/flow/extensionblocker/domain/Blocker.java
@@ -44,6 +44,9 @@ public class Blocker {
   @Column(nullable = false)
   private Type type;
 
+  @Column(nullable = false)
+  private boolean enabled;
+
   @CreatedDate
   @Column(nullable = false, updatable = false)
   private LocalDateTime createdAt;
@@ -59,15 +62,17 @@ public class Blocker {
     return Blocker.builder()
         .extension(extension.toLowerCase())
         .type(type)
+        .enabled(true)
         .build();
   }
 
   public void delete() {
+    this.enabled = false;
     this.deletedAt = LocalDateTime.now();
   }
 
   public Blocker restore() {
-    this.deletedAt = null;
+    this.enabled = true;
     return this;
   }
 }

--- a/src/main/java/flow/extensionblocker/domain/Blocker.java
+++ b/src/main/java/flow/extensionblocker/domain/Blocker.java
@@ -4,6 +4,8 @@ import flow.extensionblocker.common.annotation.ValidExtension;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -38,6 +40,10 @@ public class Blocker {
   @Column(nullable = false, updatable = false, length = 10, unique = true)
   private String extension;
 
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false)
+  private Type type;
+
   @CreatedDate
   @Column(nullable = false, updatable = false)
   private LocalDateTime createdAt;
@@ -49,9 +55,10 @@ public class Blocker {
   @Column
   private LocalDateTime deletedAt;
 
-  public static Blocker of(String extension) {
+  public static Blocker of(String extension, Type type) {
     return Blocker.builder()
         .extension(extension.toLowerCase())
+        .type(type)
         .build();
   }
 

--- a/src/main/java/flow/extensionblocker/domain/Blocker.java
+++ b/src/main/java/flow/extensionblocker/domain/Blocker.java
@@ -1,5 +1,6 @@
 package flow.extensionblocker.domain;
 
+import flow.extensionblocker.common.annotation.ValidExtension;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
@@ -8,8 +9,6 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Pattern;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -34,10 +33,7 @@ public class Blocker {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
-  @Pattern(
-      regexp = "^[a-zA-Z0-9]{1,10}$",
-      message = "확장자는 1자 이상 10자 이하의 영문 대소문자와 숫자로만 구성되어야 합니다."
-  )
+  @ValidExtension
   @Column(nullable = false, updatable = false, length = 10, unique = true)
   private String extension;
 

--- a/src/main/java/flow/extensionblocker/domain/Blocker.java
+++ b/src/main/java/flow/extensionblocker/domain/Blocker.java
@@ -1,0 +1,48 @@
+package flow.extensionblocker.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+@Getter @Builder(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(
+    name = "blockers",
+    uniqueConstraints = @UniqueConstraint(columnNames ={"extension"})
+)
+public class Blocker {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @NotBlank(message = "확장자는 필수 입력값입니다.")
+  @Pattern(
+      regexp = "^[a-zA-Z0-9]{1,10}$",
+      message = "확장자는 1자 이상 10자 이하의 영문 대소문자와 숫자로만 구성되어야 합니다."
+  )
+  @Column(nullable = false, updatable = false, length = 10, unique = true)
+  private String extension;
+
+  @CreatedDate
+  @Column(nullable = false, updatable = false)
+  private LocalDateTime blockedTime;
+}

--- a/src/main/java/flow/extensionblocker/domain/Blocker.java
+++ b/src/main/java/flow/extensionblocker/domain/Blocker.java
@@ -54,4 +54,8 @@ public class Blocker {
         .extension(extension.toLowerCase())
         .build();
   }
+
+  public void delete() {
+    this.deletedAt = LocalDateTime.now();
+  }
 }

--- a/src/main/java/flow/extensionblocker/domain/Blocker.java
+++ b/src/main/java/flow/extensionblocker/domain/Blocker.java
@@ -37,7 +37,7 @@ public class Blocker {
   private Long id;
 
   @ValidExtension
-  @Column(nullable = false, updatable = false, length = 10, unique = true)
+  @Column(nullable = false, updatable = false, length = 20, unique = true)
   private String extension;
 
   @Enumerated(EnumType.STRING)

--- a/src/main/java/flow/extensionblocker/domain/Blocker.java
+++ b/src/main/java/flow/extensionblocker/domain/Blocker.java
@@ -58,4 +58,9 @@ public class Blocker {
   public void delete() {
     this.deletedAt = LocalDateTime.now();
   }
+
+  public Blocker restore() {
+    this.deletedAt = null;
+    return this;
+  }
 }

--- a/src/main/java/flow/extensionblocker/domain/Blocker.java
+++ b/src/main/java/flow/extensionblocker/domain/Blocker.java
@@ -34,7 +34,6 @@ public class Blocker {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
-  @NotBlank(message = "확장자는 필수 입력값입니다.")
   @Pattern(
       regexp = "^[a-zA-Z0-9]{1,10}$",
       message = "확장자는 1자 이상 10자 이하의 영문 대소문자와 숫자로만 구성되어야 합니다."

--- a/src/main/java/flow/extensionblocker/domain/Blocker.java
+++ b/src/main/java/flow/extensionblocker/domain/Blocker.java
@@ -66,6 +66,14 @@ public class Blocker {
         .build();
   }
 
+  public static Blocker of(String extension, Type type, boolean enabled) {
+    return Blocker.builder()
+        .extension(extension.toLowerCase())
+        .type(type)
+        .enabled(enabled)
+        .build();
+  }
+
   public void delete() {
     this.enabled = false;
     this.deletedAt = LocalDateTime.now();

--- a/src/main/java/flow/extensionblocker/domain/Blocker.java
+++ b/src/main/java/flow/extensionblocker/domain/Blocker.java
@@ -45,4 +45,10 @@ public class Blocker {
   @CreatedDate
   @Column(nullable = false, updatable = false)
   private LocalDateTime blockedTime;
+
+  public static Blocker of(String extension) {
+    return Blocker.builder()
+        .extension(extension.toLowerCase())
+        .build();
+  }
 }

--- a/src/main/java/flow/extensionblocker/domain/Blocker.java
+++ b/src/main/java/flow/extensionblocker/domain/Blocker.java
@@ -16,6 +16,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
@@ -39,7 +40,14 @@ public class Blocker {
 
   @CreatedDate
   @Column(nullable = false, updatable = false)
-  private LocalDateTime blockedTime;
+  private LocalDateTime createdAt;
+
+  @LastModifiedDate
+  @Column(nullable = false)
+  private  LocalDateTime updatedAt;
+
+  @Column
+  private LocalDateTime deletedAt;
 
   public static Blocker of(String extension) {
     return Blocker.builder()

--- a/src/main/java/flow/extensionblocker/domain/BlockerRepository.java
+++ b/src/main/java/flow/extensionblocker/domain/BlockerRepository.java
@@ -1,0 +1,6 @@
+package flow.extensionblocker.domain;
+
+public interface BlockerRepository {
+
+  Blocker createBlocker(Blocker blocker);
+}

--- a/src/main/java/flow/extensionblocker/domain/BlockerRepository.java
+++ b/src/main/java/flow/extensionblocker/domain/BlockerRepository.java
@@ -10,4 +10,6 @@ public interface BlockerRepository {
   List<Blocker> findBlockers();
 
   Optional<Blocker> findBlocker(String extension);
+
+  Optional<Blocker> findBlockerNotDeleted(String extension);
 }

--- a/src/main/java/flow/extensionblocker/domain/BlockerRepository.java
+++ b/src/main/java/flow/extensionblocker/domain/BlockerRepository.java
@@ -1,10 +1,13 @@
 package flow.extensionblocker.domain;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface BlockerRepository {
 
   Blocker createBlocker(Blocker blocker);
+
+  List<Blocker> findBlockers();
 
   Optional<Blocker> findBlocker(String extension);
 }

--- a/src/main/java/flow/extensionblocker/domain/BlockerRepository.java
+++ b/src/main/java/flow/extensionblocker/domain/BlockerRepository.java
@@ -1,6 +1,10 @@
 package flow.extensionblocker.domain;
 
+import java.util.Optional;
+
 public interface BlockerRepository {
 
   Blocker createBlocker(Blocker blocker);
+
+  Optional<Blocker> findBlocker(String extension);
 }

--- a/src/main/java/flow/extensionblocker/domain/Type.java
+++ b/src/main/java/flow/extensionblocker/domain/Type.java
@@ -1,0 +1,6 @@
+package flow.extensionblocker.domain;
+
+public enum Type {
+  FIXED,
+  CUSTOM;
+}

--- a/src/main/java/flow/extensionblocker/infrastructure/BlockerRepositoryImpl.java
+++ b/src/main/java/flow/extensionblocker/infrastructure/BlockerRepositoryImpl.java
@@ -30,6 +30,6 @@ public class BlockerRepositoryImpl implements BlockerRepository {
 
   @Override
   public Optional<Blocker> findBlockerNotDeleted(String extension) {
-    return jpaBlockerRepository.findBlockerByExtensionAndDeletedAtIsNull(extension);
+    return jpaBlockerRepository.findBlockerByExtensionAndEnabledIsTrue(extension);
   }
 }

--- a/src/main/java/flow/extensionblocker/infrastructure/BlockerRepositoryImpl.java
+++ b/src/main/java/flow/extensionblocker/infrastructure/BlockerRepositoryImpl.java
@@ -1,0 +1,18 @@
+package flow.extensionblocker.infrastructure;
+
+import flow.extensionblocker.domain.Blocker;
+import flow.extensionblocker.domain.BlockerRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class BlockerRepositoryImpl implements BlockerRepository {
+
+  private final JpaBlockerRepository jpaBlockerRepository;
+
+  @Override
+  public Blocker createBlocker(Blocker blocker) {
+    return jpaBlockerRepository.save(blocker);
+  }
+}

--- a/src/main/java/flow/extensionblocker/infrastructure/BlockerRepositoryImpl.java
+++ b/src/main/java/flow/extensionblocker/infrastructure/BlockerRepositoryImpl.java
@@ -27,4 +27,9 @@ public class BlockerRepositoryImpl implements BlockerRepository {
   public Optional<Blocker> findBlocker(String extension) {
     return jpaBlockerRepository.findBlockerByExtension(extension);
   }
+
+  @Override
+  public Optional<Blocker> findBlockerNotDeleted(String extension) {
+    return jpaBlockerRepository.findBlockerByExtensionAndDeletedAtIsNull(extension);
+  }
 }

--- a/src/main/java/flow/extensionblocker/infrastructure/BlockerRepositoryImpl.java
+++ b/src/main/java/flow/extensionblocker/infrastructure/BlockerRepositoryImpl.java
@@ -2,6 +2,7 @@ package flow.extensionblocker.infrastructure;
 
 import flow.extensionblocker.domain.Blocker;
 import flow.extensionblocker.domain.BlockerRepository;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -14,5 +15,10 @@ public class BlockerRepositoryImpl implements BlockerRepository {
   @Override
   public Blocker createBlocker(Blocker blocker) {
     return jpaBlockerRepository.save(blocker);
+  }
+
+  @Override
+  public Optional<Blocker> findBlocker(String extension) {
+    return jpaBlockerRepository.findBlockerByExtension(extension);
   }
 }

--- a/src/main/java/flow/extensionblocker/infrastructure/BlockerRepositoryImpl.java
+++ b/src/main/java/flow/extensionblocker/infrastructure/BlockerRepositoryImpl.java
@@ -2,6 +2,7 @@ package flow.extensionblocker.infrastructure;
 
 import flow.extensionblocker.domain.Blocker;
 import flow.extensionblocker.domain.BlockerRepository;
+import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -15,6 +16,11 @@ public class BlockerRepositoryImpl implements BlockerRepository {
   @Override
   public Blocker createBlocker(Blocker blocker) {
     return jpaBlockerRepository.save(blocker);
+  }
+
+  @Override
+  public List<Blocker> findBlockers() {
+    return jpaBlockerRepository.findBlockers();
   }
 
   @Override

--- a/src/main/java/flow/extensionblocker/infrastructure/JpaBlockerRepository.java
+++ b/src/main/java/flow/extensionblocker/infrastructure/JpaBlockerRepository.java
@@ -7,7 +7,10 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 public interface JpaBlockerRepository extends JpaRepository<Blocker, Long> {
+
   Optional<Blocker> findBlockerByExtension(String extension);
+
+  Optional<Blocker> findBlockerByExtensionAndDeletedAtIsNull(String extension);
 
   @Query("SELECT b FROM Blocker b WHERE b.deletedAt IS NULL")
   List<Blocker> findBlockers();

--- a/src/main/java/flow/extensionblocker/infrastructure/JpaBlockerRepository.java
+++ b/src/main/java/flow/extensionblocker/infrastructure/JpaBlockerRepository.java
@@ -1,6 +1,9 @@
 package flow.extensionblocker.infrastructure;
 
 import flow.extensionblocker.domain.Blocker;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface JpaBlockerRepository extends JpaRepository<Blocker, Long> {}
+public interface JpaBlockerRepository extends JpaRepository<Blocker, Long> {
+  Optional<Blocker> findBlockerByExtension(String extension);
+}

--- a/src/main/java/flow/extensionblocker/infrastructure/JpaBlockerRepository.java
+++ b/src/main/java/flow/extensionblocker/infrastructure/JpaBlockerRepository.java
@@ -10,8 +10,8 @@ public interface JpaBlockerRepository extends JpaRepository<Blocker, Long> {
 
   Optional<Blocker> findBlockerByExtension(String extension);
 
-  Optional<Blocker> findBlockerByExtensionAndDeletedAtIsNull(String extension);
+  Optional<Blocker> findBlockerByExtensionAndEnabledIsTrue(String extension);
 
-  @Query("SELECT b FROM Blocker b WHERE b.deletedAt IS NULL")
+  @Query("SELECT b FROM Blocker b WHERE b.enabled = true")
   List<Blocker> findBlockers();
 }

--- a/src/main/java/flow/extensionblocker/infrastructure/JpaBlockerRepository.java
+++ b/src/main/java/flow/extensionblocker/infrastructure/JpaBlockerRepository.java
@@ -1,9 +1,14 @@
 package flow.extensionblocker.infrastructure;
 
 import flow.extensionblocker.domain.Blocker;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface JpaBlockerRepository extends JpaRepository<Blocker, Long> {
   Optional<Blocker> findBlockerByExtension(String extension);
+
+  @Query("SELECT b FROM Blocker b WHERE b.deletedAt IS NULL")
+  List<Blocker> findBlockers();
 }

--- a/src/main/java/flow/extensionblocker/infrastructure/JpaBlockerRepository.java
+++ b/src/main/java/flow/extensionblocker/infrastructure/JpaBlockerRepository.java
@@ -1,0 +1,6 @@
+package flow.extensionblocker.infrastructure;
+
+import flow.extensionblocker.domain.Blocker;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface JpaBlockerRepository extends JpaRepository<Blocker, Long> {}

--- a/src/main/java/flow/extensionblocker/infrastructure/config/FixedBlockerInitializer.java
+++ b/src/main/java/flow/extensionblocker/infrastructure/config/FixedBlockerInitializer.java
@@ -1,0 +1,34 @@
+package flow.extensionblocker.infrastructure.config;
+
+import flow.extensionblocker.domain.Blocker;
+import flow.extensionblocker.domain.BlockerRepository;
+import flow.extensionblocker.domain.Type;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class FixedBlockerInitializer implements ApplicationRunner {
+
+  private final BlockerRepository blockerRepository;
+
+  public static final List<String> FIXED_EXTENSIONS = List.of(
+      "bat", "cmd", "com", "cpl", "exe", "scr", "js"
+  );
+
+  @Override
+  @Transactional
+  public void run(ApplicationArguments args) throws Exception {
+    FIXED_EXTENSIONS.stream()
+        .filter(extension -> blockerRepository
+            .findBlocker((extension))
+            .isEmpty()
+        )
+        .map(left -> Blocker.of(left, Type.FIXED, false))
+        .forEach(blockerRepository::createBlocker);
+  }
+}

--- a/src/main/java/flow/extensionblocker/infrastructure/persistence/BlockerRepositoryImpl.java
+++ b/src/main/java/flow/extensionblocker/infrastructure/persistence/BlockerRepositoryImpl.java
@@ -1,4 +1,4 @@
-package flow.extensionblocker.infrastructure;
+package flow.extensionblocker.infrastructure.persistence;
 
 import flow.extensionblocker.domain.Blocker;
 import flow.extensionblocker.domain.BlockerRepository;

--- a/src/main/java/flow/extensionblocker/infrastructure/persistence/JpaBlockerRepository.java
+++ b/src/main/java/flow/extensionblocker/infrastructure/persistence/JpaBlockerRepository.java
@@ -1,4 +1,4 @@
-package flow.extensionblocker.infrastructure;
+package flow.extensionblocker.infrastructure.persistence;
 
 import flow.extensionblocker.domain.Blocker;
 import java.util.List;

--- a/src/main/java/flow/extensionblocker/presentation/controller/BlockerController.java
+++ b/src/main/java/flow/extensionblocker/presentation/controller/BlockerController.java
@@ -1,0 +1,25 @@
+package flow.extensionblocker.presentation.controller;
+
+import flow.extensionblocker.application.BlockerService;
+import flow.extensionblocker.application.dto.CreateBlockerRequest;
+import flow.extensionblocker.application.dto.CreateBlockerResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController // TODO controller 로 변경
+@RequiredArgsConstructor
+@RequestMapping("/blocker")
+public class BlockerController {
+
+  private final BlockerService blockerService;
+
+  @PostMapping
+  public ResponseEntity<CreateBlockerResponse> createBlocker(@RequestBody CreateBlockerRequest request) {
+    return ResponseEntity.ok(blockerService.createBlocker(request));
+  }
+}

--- a/src/main/java/flow/extensionblocker/presentation/controller/BlockerController.java
+++ b/src/main/java/flow/extensionblocker/presentation/controller/BlockerController.java
@@ -9,6 +9,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -29,5 +31,11 @@ public class BlockerController {
   @GetMapping
   public ResponseEntity<List<BlockerResponse>> getBlockers() {
     return ResponseEntity.ok(blockerService.getBlockers());
+  }
+
+  @PatchMapping("/{extension}")
+  public ResponseEntity<Void> deleteBlocker(@PathVariable String extension) {
+    blockerService.deleteBlocker(extension);
+    return ResponseEntity.noContent().build();
   }
 }

--- a/src/main/java/flow/extensionblocker/presentation/controller/BlockerController.java
+++ b/src/main/java/flow/extensionblocker/presentation/controller/BlockerController.java
@@ -1,11 +1,14 @@
 package flow.extensionblocker.presentation.controller;
 
 import flow.extensionblocker.application.BlockerService;
+import flow.extensionblocker.application.dto.BlockerResponse;
 import flow.extensionblocker.application.dto.CreateBlockerRequest;
 import flow.extensionblocker.application.dto.CreateBlockerResponse;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -21,5 +24,10 @@ public class BlockerController {
   @PostMapping
   public ResponseEntity<CreateBlockerResponse> createBlocker(@RequestBody CreateBlockerRequest request) {
     return ResponseEntity.ok(blockerService.createBlocker(request));
+  }
+
+  @GetMapping
+  public ResponseEntity<List<BlockerResponse>> getBlockers() {
+    return ResponseEntity.ok(blockerService.getBlockers());
   }
 }

--- a/src/main/java/flow/extensionblocker/presentation/controller/BlockerController.java
+++ b/src/main/java/flow/extensionblocker/presentation/controller/BlockerController.java
@@ -4,6 +4,7 @@ import flow.extensionblocker.application.BlockerService;
 import flow.extensionblocker.application.dto.BlockerResponse;
 import flow.extensionblocker.application.dto.CreateBlockerRequest;
 import flow.extensionblocker.application.dto.CreateBlockerResponse;
+import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -24,7 +25,9 @@ public class BlockerController {
   private final BlockerService blockerService;
 
   @PostMapping
-  public ResponseEntity<CreateBlockerResponse> createBlocker(@RequestBody CreateBlockerRequest request) {
+  public ResponseEntity<CreateBlockerResponse> createBlocker(
+      @Valid @RequestBody CreateBlockerRequest request
+  ) {
     return ResponseEntity.ok(blockerService.createBlocker(request));
   }
 

--- a/src/main/java/flow/extensionblocker/presentation/controller/BlockerController.java
+++ b/src/main/java/flow/extensionblocker/presentation/controller/BlockerController.java
@@ -18,7 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController // TODO controller 로 변경
 @RequiredArgsConstructor
-@RequestMapping("/blocker")
+@RequestMapping("/blockers")
 public class BlockerController {
 
   private final BlockerService blockerService;

--- a/src/main/java/flow/extensionblocker/presentation/controller/UploadController.java
+++ b/src/main/java/flow/extensionblocker/presentation/controller/UploadController.java
@@ -1,0 +1,20 @@
+package flow.extensionblocker.presentation.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequestMapping("/uploads")
+public class UploadController {
+
+  @PostMapping
+  public ResponseEntity<HttpStatus> upload(@RequestBody MultipartFile file) {
+    // 실질적으로 파일 저장은 하지 않음
+    return ResponseEntity.status(HttpStatus.CREATED).body(HttpStatus.CREATED); // 201
+  }
+}

--- a/src/main/java/flow/extensionblocker/presentation/filter/ExtensionBlockerFilter.java
+++ b/src/main/java/flow/extensionblocker/presentation/filter/ExtensionBlockerFilter.java
@@ -1,0 +1,50 @@
+package flow.extensionblocker.presentation.filter;
+
+import flow.extensionblocker.application.BlockerService;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.Part;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+@RequiredArgsConstructor
+public class ExtensionBlockerFilter extends OncePerRequestFilter {
+
+  private final BlockerService blockerService;
+
+  @Override
+  protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
+    String path = request.getServletPath();
+    String method = request.getMethod();
+
+    return !"POST".equals(method) && !path.startsWith("/uploads");
+  }
+
+  @Override
+  protected void doFilterInternal(
+      HttpServletRequest request,
+      HttpServletResponse response,
+      FilterChain filterChain
+  ) throws ServletException, IOException {
+    Part part = request.getPart("file");
+    String filename = part.getSubmittedFileName();
+    String extension = filename.substring(filename.lastIndexOf('.') + 1).toLowerCase();
+
+    if (blockerService.isBlocked(extension)) {
+      response.sendError(
+          HttpStatus.UNSUPPORTED_MEDIA_TYPE.value(), // 415
+          extension + " 확장자는 차단되었습니다."
+      );
+
+      return;
+    }
+
+    filterChain.doFilter(request, response);
+  }
+}

--- a/src/main/java/flow/extensionblocker/presentation/filter/ExtensionBlockerFilter.java
+++ b/src/main/java/flow/extensionblocker/presentation/filter/ExtensionBlockerFilter.java
@@ -23,7 +23,7 @@ public class ExtensionBlockerFilter extends OncePerRequestFilter {
     String path = request.getServletPath();
     String method = request.getMethod();
 
-    return !"POST".equals(method) && !path.startsWith("/uploads");
+    return !"POST".equals(method) || !path.startsWith("/uploads");
   }
 
   @Override

--- a/src/test/java/flow/extensionblocker/application/BlockerServiceTest.java
+++ b/src/test/java/flow/extensionblocker/application/BlockerServiceTest.java
@@ -1,0 +1,62 @@
+package flow.extensionblocker.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.any;
+import static org.mockito.BDDMockito.given;
+
+import flow.extensionblocker.domain.BlockerRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class BlockerServiceTest {
+
+  @Nested
+  @DisplayName("서비스 레이어 레벨 차단기 생성 테스트")
+  class CreateBlocker {
+
+    @Mock
+    private BlockerRepository blockerRepository;
+
+    @InjectMocks
+    private BlockerService sut;
+
+    @BeforeEach
+    void setUp() {
+      given(blockerRepository.createBlocker(any()))
+          .willAnswer(invocation -> invocation.getArgument(0));
+    }
+
+    @Test
+    @DisplayName("하나의 확장자에 대한 차단기를 생성한다")
+    void test1() {
+      // Given
+      String input = "exe";
+
+      // When
+      var response = sut.createBlocker(input);
+
+      // Then
+      assertThat(response.extension()).isEqualTo("exe");
+    }
+
+    @Test
+    @DisplayName("입력값이 대문자로 주어진 경우에도 소문자로 변환하여 차단기를 생성한다")
+    void test2() {
+      // Given
+      String input = "EXE";
+
+      // When
+      var response = sut.createBlocker(input);
+
+      // Then
+      assertThat(response.extension()).isEqualTo("exe");
+    }
+  }
+}

--- a/src/test/java/flow/extensionblocker/application/BlockerServiceTest.java
+++ b/src/test/java/flow/extensionblocker/application/BlockerServiceTest.java
@@ -84,7 +84,8 @@ class BlockerServiceTest {
       var response = sut.createBlocker(input);
 
       // Then
-      assertThat(blocker.getDeletedAt()).isNull();
+      assertThat(blocker.getDeletedAt()).isNotNull();
+      assertThat(blocker.isEnabled()).isTrue();
       assertThat(response.extension()).isEqualTo("exe");
     }
   }

--- a/src/test/java/flow/extensionblocker/application/BlockerServiceTest.java
+++ b/src/test/java/flow/extensionblocker/application/BlockerServiceTest.java
@@ -7,6 +7,7 @@ import static org.mockito.BDDMockito.given;
 import flow.extensionblocker.application.dto.CreateBlockerRequest;
 import flow.extensionblocker.domain.Blocker;
 import flow.extensionblocker.domain.BlockerRepository;
+import flow.extensionblocker.domain.Type;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -40,7 +41,7 @@ class BlockerServiceTest {
     @DisplayName("하나의 확장자에 대한 차단기를 생성한다")
     void test1() {
       // Given
-      CreateBlockerRequest input = new CreateBlockerRequest("exe");
+      CreateBlockerRequest input = new CreateBlockerRequest("exe", Type.CUSTOM);
 
       // When
       var response = sut.createBlocker(input);
@@ -53,7 +54,7 @@ class BlockerServiceTest {
     @DisplayName("입력값이 대문자로 주어진 경우에도 소문자로 변환하여 차단기를 생성한다")
     void test2() {
       // Given
-      CreateBlockerRequest input = new CreateBlockerRequest("EXE");
+      CreateBlockerRequest input = new CreateBlockerRequest("EXE", Type.CUSTOM);
 
       // When
       var response = sut.createBlocker(input);
@@ -71,13 +72,13 @@ class BlockerServiceTest {
     @DisplayName("논리적으로 삭제된 차단기를 다시 생성할 수 있다.")
     void test4() {
       // Given
-      Blocker blocker = Blocker.of("exe");
+      Blocker blocker = Blocker.of("exe", Type.CUSTOM);
       blocker.delete();
 
       given(blockerRepository.findBlocker("exe"))
           .willReturn(Optional.of(blocker));
 
-      CreateBlockerRequest input = new CreateBlockerRequest("exe");
+      CreateBlockerRequest input = new CreateBlockerRequest("exe", Type.CUSTOM);
 
       // When
       var response = sut.createBlocker(input);
@@ -96,7 +97,7 @@ class BlockerServiceTest {
 
     @BeforeEach
     void setUp() {
-      blocker = Blocker.of("exe");
+      blocker = Blocker.of("exe", Type.CUSTOM);
       given(blockerRepository.findBlocker(any()))
           .willReturn(Optional.of(blocker));
     }

--- a/src/test/java/flow/extensionblocker/application/BlockerServiceTest.java
+++ b/src/test/java/flow/extensionblocker/application/BlockerServiceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.any;
 import static org.mockito.BDDMockito.given;
 
+import flow.extensionblocker.application.dto.CreateBlockerRequest;
 import flow.extensionblocker.domain.BlockerRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -37,7 +38,7 @@ class BlockerServiceTest {
     @DisplayName("하나의 확장자에 대한 차단기를 생성한다")
     void test1() {
       // Given
-      String input = "exe";
+      CreateBlockerRequest input = new CreateBlockerRequest("exe");
 
       // When
       var response = sut.createBlocker(input);
@@ -50,7 +51,7 @@ class BlockerServiceTest {
     @DisplayName("입력값이 대문자로 주어진 경우에도 소문자로 변환하여 차단기를 생성한다")
     void test2() {
       // Given
-      String input = "EXE";
+      CreateBlockerRequest input = new CreateBlockerRequest("EXE");
 
       // When
       var response = sut.createBlocker(input);

--- a/src/test/java/flow/extensionblocker/application/BlockerServiceTest.java
+++ b/src/test/java/flow/extensionblocker/application/BlockerServiceTest.java
@@ -20,15 +20,15 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class BlockerServiceTest {
 
+  @Mock
+  private BlockerRepository blockerRepository;
+
+  @InjectMocks
+  private BlockerService sut;
+
   @Nested
   @DisplayName("차단기 생성 테스트")
   class CreateBlocker {
-
-    @Mock
-    private BlockerRepository blockerRepository;
-
-    @InjectMocks
-    private BlockerService sut;
 
     @BeforeEach
     void setUp() {
@@ -64,14 +64,33 @@ class BlockerServiceTest {
   }
 
   @Nested
+  @DisplayName("차단기 생성 시나리오 테스트")
+  class CreateBlockerScenario {
+
+    @Test
+    @DisplayName("논리적으로 삭제된 차단기를 다시 생성할 수 있다.")
+    void test4() {
+      // Given
+      Blocker blocker = Blocker.of("exe");
+      blocker.delete();
+
+      given(blockerRepository.findBlocker("exe"))
+          .willReturn(Optional.of(blocker));
+
+      CreateBlockerRequest input = new CreateBlockerRequest("exe");
+
+      // When
+      var response = sut.createBlocker(input);
+
+      // Then
+      assertThat(blocker.getDeletedAt()).isNull();
+      assertThat(response.extension()).isEqualTo("exe");
+    }
+  }
+
+  @Nested
   @DisplayName("차단기 삭제 테스트")
   class DeleteBlocker {
-
-    @Mock
-    private BlockerRepository blockerRepository;
-
-    @InjectMocks
-    private BlockerService sut;
 
     Blocker blocker;
 

--- a/src/test/java/flow/extensionblocker/application/BlockerServiceTest.java
+++ b/src/test/java/flow/extensionblocker/application/BlockerServiceTest.java
@@ -5,7 +5,9 @@ import static org.mockito.BDDMockito.any;
 import static org.mockito.BDDMockito.given;
 
 import flow.extensionblocker.application.dto.CreateBlockerRequest;
+import flow.extensionblocker.domain.Blocker;
 import flow.extensionblocker.domain.BlockerRepository;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -58,6 +60,37 @@ class BlockerServiceTest {
 
       // Then
       assertThat(response.extension()).isEqualTo("exe");
+    }
+  }
+
+  @Nested
+  @DisplayName("차단기 삭제 테스트")
+  class DeleteBlocker {
+
+    @Mock
+    private BlockerRepository blockerRepository;
+
+    @InjectMocks
+    private BlockerService sut;
+
+    Blocker blocker;
+
+    @BeforeEach
+    void setUp() {
+      blocker = Blocker.of("exe");
+      given(blockerRepository.findBlocker(any()))
+          .willReturn(Optional.of(blocker));
+    }
+
+    @Test
+    @DisplayName("차단기를 논리적으로 삭제한다")
+    void test1() {
+      // When
+      sut.deleteBlocker("exe");
+
+      // Then
+      assertThat(blocker.getDeletedAt()).isNotNull();
+      assertThat(blocker.getExtension()).isEqualTo("exe");
     }
   }
 }

--- a/src/test/java/flow/extensionblocker/application/BlockerServiceTest.java
+++ b/src/test/java/flow/extensionblocker/application/BlockerServiceTest.java
@@ -19,7 +19,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class BlockerServiceTest {
 
   @Nested
-  @DisplayName("서비스 레이어 레벨 차단기 생성 테스트")
+  @DisplayName("차단기 생성 테스트")
   class CreateBlocker {
 
     @Mock

--- a/src/test/java/flow/extensionblocker/domain/BlockerTest.java
+++ b/src/test/java/flow/extensionblocker/domain/BlockerTest.java
@@ -1,0 +1,117 @@
+package flow.extensionblocker.domain;
+
+import static jakarta.validation.Validation.buildDefaultValidatorFactory;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validator;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class BlockerTest {
+
+  @Nested
+  @DisplayName("차단기 도메인 검증 테스트")
+  class BlockerValidationTest {
+
+    private final Validator validator = buildDefaultValidatorFactory().getValidator();
+
+    @Test
+    @DisplayName("1자에 대한 확장자 차단기를 생성할 수 있다")
+    void test_success_1() {
+      // Given
+      String input = "a";
+
+      // When
+      var blocker = Blocker.of(input);
+      var violations = validator.validate(blocker);
+
+      // Then
+      assertThat(violations).isEmpty();
+      assertThat(blocker.getExtension()).isEqualTo("a");
+    }
+
+    @Test
+    @DisplayName("10자에 대한 확장자 차단기를 생성할 수 있다")
+    void test_success_2() {
+      // Given
+      String input = "abcdefghij";
+
+      // When
+      var blocker = Blocker.of(input);
+      var violations = validator.validate(blocker);
+
+      // Then
+      assertThat(violations).isEmpty();
+      assertThat(blocker.getExtension()).isEqualTo("abcdefghij");
+    }
+
+    @Test
+    @DisplayName("빈 확장자에 대한 차단기를 생성할 수 없다")
+    void test_fail_1() {
+      // Given
+      String input = "";
+
+      // When
+      var blocker = Blocker.of(input);
+      var violations = validator.validate(blocker);
+
+      // Then
+      assertThat(violations)
+          .extracting(ConstraintViolation::getMessage)
+          .containsExactly("확장자는 1자 이상 10자 이하의 영문 대소문자와 숫자로만 구성되어야 합니다.");
+    }
+
+    @Test
+    @DisplayName("10자 이상의 확장자에 대한 차단기를 생성할 수 없다")
+    void test_fail_2() {
+      // Given
+      String input = "abcdefghijk";
+
+      // When
+      var blocker = Blocker.of(input);
+      var violations = validator.validate(blocker);
+
+      // Then
+      assertThat(violations)
+          .extracting(ConstraintViolation::getMessage)
+          .containsExactly("확장자는 1자 이상 10자 이하의 영문 대소문자와 숫자로만 구성되어야 합니다.");
+    }
+
+    @Test
+    @DisplayName("특수 문자를 포함한 확장자에 대한 차단기를 생성할 수 없다")
+    void test_fail_3() {
+      // Given
+      String input = "abcdef*";
+
+      // When
+      var blocker = Blocker.of(input);
+      var violations = validator.validate(blocker);
+
+      // Then
+      assertThat(violations)
+          .extracting(ConstraintViolation::getMessage)
+          .containsExactly("확장자는 1자 이상 10자 이하의 영문 대소문자와 숫자로만 구성되어야 합니다.");
+    }
+
+    @Test
+    @DisplayName("공백을 포함한 확장자에 대한 차단기를 생성할 수 없다")
+    void test_fail_4() {
+      // Given
+      String input = "abc def";
+
+      // When
+      var blocker = Blocker.of(input);
+      var violations = validator.validate(blocker);
+
+      // Then
+      assertThat(violations)
+          .extracting(ConstraintViolation::getMessage)
+          .containsExactly("확장자는 1자 이상 10자 이하의 영문 대소문자와 숫자로만 구성되어야 합니다.");
+    }
+  }
+}

--- a/src/test/java/flow/extensionblocker/domain/BlockerTest.java
+++ b/src/test/java/flow/extensionblocker/domain/BlockerTest.java
@@ -67,7 +67,7 @@ class BlockerTest {
     }
 
     @Test
-    @DisplayName("10자 이상의 확장자에 대한 차단기를 생성할 수 없다")
+    @DisplayName("20자를 초과한 확장자에 대한 차단기를 생성할 수 없다")
     void test_fail_2() {
       // Given
       String input = "abcdefghijklmopqrstuv";

--- a/src/test/java/flow/extensionblocker/domain/BlockerTest.java
+++ b/src/test/java/flow/extensionblocker/domain/BlockerTest.java
@@ -36,10 +36,10 @@ class BlockerTest {
     }
 
     @Test
-    @DisplayName("10자에 대한 확장자 차단기를 생성할 수 있다")
+    @DisplayName("20자에 대한 확장자 차단기를 생성할 수 있다")
     void test_success_2() {
       // Given
-      String input = "abcdefghij";
+      String input = "abcdefghijklmopqrstu";
 
       // When
       var blocker = Blocker.of(input, Type.CUSTOM);
@@ -47,7 +47,7 @@ class BlockerTest {
 
       // Then
       assertThat(violations).isEmpty();
-      assertThat(blocker.getExtension()).isEqualTo("abcdefghij");
+      assertThat(blocker.getExtension()).isEqualTo("abcdefghijklmopqrstu");
     }
 
     @Test
@@ -63,14 +63,14 @@ class BlockerTest {
       // Then
       assertThat(violations)
           .extracting(ConstraintViolation::getMessage)
-          .containsExactly("확장자는 1자 이상 10자 이하의 영문 대소문자와 숫자로만 구성되어야 합니다.");
+          .containsExactly("확장자는 1자 이상 20자 이하의 영문 대소문자와 숫자로만 구성되어야 합니다.");
     }
 
     @Test
     @DisplayName("10자 이상의 확장자에 대한 차단기를 생성할 수 없다")
     void test_fail_2() {
       // Given
-      String input = "abcdefghijk";
+      String input = "abcdefghijklmopqrstuv";
 
       // When
       var blocker = Blocker.of(input, Type.CUSTOM);
@@ -79,7 +79,7 @@ class BlockerTest {
       // Then
       assertThat(violations)
           .extracting(ConstraintViolation::getMessage)
-          .containsExactly("확장자는 1자 이상 10자 이하의 영문 대소문자와 숫자로만 구성되어야 합니다.");
+          .containsExactly("확장자는 1자 이상 20자 이하의 영문 대소문자와 숫자로만 구성되어야 합니다.");
     }
 
     @Test
@@ -95,7 +95,7 @@ class BlockerTest {
       // Then
       assertThat(violations)
           .extracting(ConstraintViolation::getMessage)
-          .containsExactly("확장자는 1자 이상 10자 이하의 영문 대소문자와 숫자로만 구성되어야 합니다.");
+          .containsExactly("확장자는 1자 이상 20자 이하의 영문 대소문자와 숫자로만 구성되어야 합니다.");
     }
 
     @Test
@@ -111,7 +111,7 @@ class BlockerTest {
       // Then
       assertThat(violations)
           .extracting(ConstraintViolation::getMessage)
-          .containsExactly("확장자는 1자 이상 10자 이하의 영문 대소문자와 숫자로만 구성되어야 합니다.");
+          .containsExactly("확장자는 1자 이상 20자 이하의 영문 대소문자와 숫자로만 구성되어야 합니다.");
     }
   }
 }

--- a/src/test/java/flow/extensionblocker/domain/BlockerTest.java
+++ b/src/test/java/flow/extensionblocker/domain/BlockerTest.java
@@ -27,7 +27,7 @@ class BlockerTest {
       String input = "a";
 
       // When
-      var blocker = Blocker.of(input);
+      var blocker = Blocker.of(input, Type.CUSTOM);
       var violations = validator.validate(blocker);
 
       // Then
@@ -42,7 +42,7 @@ class BlockerTest {
       String input = "abcdefghij";
 
       // When
-      var blocker = Blocker.of(input);
+      var blocker = Blocker.of(input, Type.CUSTOM);
       var violations = validator.validate(blocker);
 
       // Then
@@ -57,7 +57,7 @@ class BlockerTest {
       String input = "";
 
       // When
-      var blocker = Blocker.of(input);
+      var blocker = Blocker.of(input, Type.CUSTOM);
       var violations = validator.validate(blocker);
 
       // Then
@@ -73,7 +73,7 @@ class BlockerTest {
       String input = "abcdefghijk";
 
       // When
-      var blocker = Blocker.of(input);
+      var blocker = Blocker.of(input, Type.CUSTOM);
       var violations = validator.validate(blocker);
 
       // Then
@@ -89,7 +89,7 @@ class BlockerTest {
       String input = "abcdef*";
 
       // When
-      var blocker = Blocker.of(input);
+      var blocker = Blocker.of(input, Type.CUSTOM);
       var violations = validator.validate(blocker);
 
       // Then
@@ -105,7 +105,7 @@ class BlockerTest {
       String input = "abc def";
 
       // When
-      var blocker = Blocker.of(input);
+      var blocker = Blocker.of(input, Type.CUSTOM);
       var violations = validator.validate(blocker);
 
       // Then

--- a/src/test/java/flow/extensionblocker/infrastructure/JpaBlockerRepositoryTest.java
+++ b/src/test/java/flow/extensionblocker/infrastructure/JpaBlockerRepositoryTest.java
@@ -38,6 +38,20 @@ class JpaBlockerRepositoryTest {
     }
 
     @Test
+    @DisplayName("삭제된 차단기는 조회되지 않는다")
+    void test2() {
+      // Given
+      var blocker = sut.save(Blocker.of("exe"));
+      blocker.delete();
+
+      // When
+      var blockers = sut.findBlockers();
+
+      // Then
+      assertFalse(blockers.stream().anyMatch(b -> b.getExtension().equals("exe")));
+    }
+
+    @Test
     @DisplayName("차단기가 없는 경우 빈 리스트를 반환한다")
     void test3() {
       // When

--- a/src/test/java/flow/extensionblocker/infrastructure/JpaBlockerRepositoryTest.java
+++ b/src/test/java/flow/extensionblocker/infrastructure/JpaBlockerRepositoryTest.java
@@ -3,6 +3,7 @@ package flow.extensionblocker.infrastructure;
 import static org.junit.jupiter.api.Assertions.*;
 
 import flow.extensionblocker.domain.Blocker;
+import flow.extensionblocker.domain.Type;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -25,8 +26,8 @@ class JpaBlockerRepositoryTest {
     @DisplayName("차단기를 모두 조회한다")
     void test1() {
       // Given
-      sut.save(Blocker.of("exe"));
-      sut.save(Blocker.of("bat"));
+      sut.save(Blocker.of("exe", Type.CUSTOM));
+      sut.save(Blocker.of("bat", Type.CUSTOM));
 
       // When
       var blockers = sut.findBlockers();
@@ -41,7 +42,7 @@ class JpaBlockerRepositoryTest {
     @DisplayName("삭제된 차단기는 조회되지 않는다")
     void test2() {
       // Given
-      var blocker = sut.save(Blocker.of("exe"));
+      var blocker = sut.save(Blocker.of("exe", Type.CUSTOM));
       blocker.delete();
 
       // When
@@ -71,7 +72,7 @@ class JpaBlockerRepositoryTest {
     void test1() {
       // Given
       String extension = "exe";
-      sut.save(Blocker.of(extension));
+      sut.save(Blocker.of(extension, Type.CUSTOM));
 
       // When
       var blocker = sut.findBlockerByExtension(extension);

--- a/src/test/java/flow/extensionblocker/infrastructure/JpaBlockerRepositoryTest.java
+++ b/src/test/java/flow/extensionblocker/infrastructure/JpaBlockerRepositoryTest.java
@@ -18,6 +18,37 @@ class JpaBlockerRepositoryTest {
   private JpaBlockerRepository sut;
 
   @Nested
+  @DisplayName("차단기 전체 조회 테스트")
+  class FindBlockers {
+
+    @Test
+    @DisplayName("차단기를 모두 조회한다")
+    void test1() {
+      // Given
+      sut.save(Blocker.of("exe"));
+      sut.save(Blocker.of("bat"));
+
+      // When
+      var blockers = sut.findBlockers();
+
+      // Then
+      assertEquals(2, blockers.size());
+      assertTrue(blockers.stream().anyMatch(b -> b.getExtension().equals("exe")));
+      assertTrue(blockers.stream().anyMatch(b -> b.getExtension().equals("bat")));
+    }
+
+    @Test
+    @DisplayName("차단기가 없는 경우 빈 리스트를 반환한다")
+    void test3() {
+      // When
+      var blockers = sut.findBlockers();
+
+      // Then
+      assertTrue(blockers.isEmpty());
+    }
+  }
+
+  @Nested
   @DisplayName("차단기 조회 테스트")
   class FindBlocker {
 

--- a/src/test/java/flow/extensionblocker/infrastructure/JpaBlockerRepositoryTest.java
+++ b/src/test/java/flow/extensionblocker/infrastructure/JpaBlockerRepositoryTest.java
@@ -1,0 +1,52 @@
+package flow.extensionblocker.infrastructure;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import flow.extensionblocker.domain.Blocker;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class JpaBlockerRepositoryTest {
+
+  @Autowired
+  private JpaBlockerRepository sut;
+
+  @Nested
+  @DisplayName("차단기 조회 테스트")
+  class FindBlocker {
+
+    @Test
+    @DisplayName("확장자에 해당하는 차단기를 조회한다")
+    void test1() {
+      // Given
+      String extension = "exe";
+      sut.save(Blocker.of(extension));
+
+      // When
+      var blocker = sut.findBlockerByExtension(extension);
+
+      // Then
+      assertTrue(blocker.isPresent());
+      assertEquals(extension, blocker.get().getExtension());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 확장자에 대한 차단기는 조회되지 않는다")
+    void test2() {
+      // Given
+      String extension = "nonexistent";
+
+      // When
+      var blocker = sut.findBlockerByExtension(extension);
+
+      // Then
+      assertFalse(blocker.isPresent());
+    }
+  }
+}

--- a/src/test/java/flow/extensionblocker/infrastructure/JpaBlockerRepositoryTest.java
+++ b/src/test/java/flow/extensionblocker/infrastructure/JpaBlockerRepositoryTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import flow.extensionblocker.domain.Blocker;
 import flow.extensionblocker.domain.Type;
+import flow.extensionblocker.infrastructure.persistence.JpaBlockerRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/flow/extensionblocker/infrastructure/config/FixedBlockerInitializerTest.java
+++ b/src/test/java/flow/extensionblocker/infrastructure/config/FixedBlockerInitializerTest.java
@@ -1,0 +1,70 @@
+package flow.extensionblocker.infrastructure.config;
+
+import static org.mockito.BDDMockito.any;
+import static org.mockito.BDDMockito.argThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.never;
+import static org.mockito.BDDMockito.times;
+import static org.mockito.BDDMockito.verify;
+
+import flow.extensionblocker.domain.Blocker;
+import flow.extensionblocker.domain.BlockerRepository;
+import flow.extensionblocker.domain.Type;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class FixedBlockerInitializerTest {
+
+  @Mock
+  private BlockerRepository blockerRepository;
+
+  @InjectMocks
+  private FixedBlockerInitializer sut;
+
+  @Test
+  @DisplayName("저장되어 있지 않은 고정 확장자만 비활성화 상태로 미리 생성한다.")
+  void test1() throws Exception {
+    // Given
+    var extensions = sut.FIXED_EXTENSIONS;
+    extensions.forEach(extension -> {
+      given(blockerRepository.findBlocker(extension)).willReturn(Optional.empty());
+    });
+
+    // When
+    sut.run(null);
+
+    // Then
+    extensions.forEach(extension -> {
+      verify(blockerRepository, times(1))
+          .createBlocker(
+              argThat(e ->
+                  e.getType() == Type.FIXED &&
+                  e.getExtension().equals(extension)
+              )
+          );
+    });
+  }
+
+  @Test
+  @DisplayName("이미 저장되어 있는 고정 확장자는 생성하지 않는다.")
+  void test2() throws Exception {
+    // Given
+    var extensions = sut.FIXED_EXTENSIONS;
+    extensions.forEach(extension -> {
+      given(blockerRepository.findBlocker(extension))
+          .willReturn(Optional.of(Blocker.of(extension, Type.FIXED, false)));
+    });
+
+    // When
+    sut.run(null);
+
+    // Then
+    verify(blockerRepository, never()).createBlocker(any());
+  }
+}

--- a/src/test/java/flow/extensionblocker/presentation/filter/ExtensionBlockerFilterTest.java
+++ b/src/test/java/flow/extensionblocker/presentation/filter/ExtensionBlockerFilterTest.java
@@ -1,0 +1,89 @@
+package flow.extensionblocker.presentation.filter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import flow.extensionblocker.application.BlockerService;
+import jakarta.servlet.ServletException;
+import java.io.IOException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.mock.web.MockPart;
+
+@ExtendWith(MockitoExtension.class)
+class ExtensionBlockerFilterTest {
+
+  @Mock
+  private BlockerService blockerService;
+
+  @Mock
+  private MockFilterChain chain;
+
+  @InjectMocks
+  private ExtensionBlockerFilter sut;
+
+  @Test
+  @DisplayName("차단된 확장자에 대한 upload 요청은 415 에러를 반환한다")
+  void test1() throws ServletException, IOException {
+    // Given
+    var request = new MockHttpServletRequest();
+    request.setMethod("POST");
+    request.setServletPath("/uploads");
+    request.addPart(new MockPart("file", "test.exe", new byte[0]));
+
+    var response = new MockHttpServletResponse();
+
+    given(blockerService.isBlocked("exe")).willReturn(true);
+
+    // When
+    sut.doFilterInternal(request, response, chain);
+
+    // Then
+    assertThat(response.getStatus()).isEqualTo(HttpStatus.UNSUPPORTED_MEDIA_TYPE.value());
+  }
+
+  @Test
+  @DisplayName("차단되지 않은 확장자에 대한 upload 요청은 정상적으로 처리된다")
+  void test2() throws ServletException, IOException {
+    // Given
+    var request = new MockHttpServletRequest();
+    request.setMethod("POST");
+    request.setServletPath("/uploads");
+    request.addPart(new MockPart("file", "test.txt", new byte[0]));
+
+    var response = new MockHttpServletResponse();
+
+    given(blockerService.isBlocked("txt")).willReturn(false);
+
+    // When
+    sut.doFilterInternal(request, response, chain);
+
+    // Then
+    assertThat(response.getStatus()).isEqualTo(HttpStatus.OK.value());
+  }
+
+  @Test
+  @DisplayName("upload 요청이 아닌 경우 필터가 동작하지 않는다")
+  void test3() throws ServletException, IOException {
+    // Given
+    var request = new MockHttpServletRequest();
+    request.setMethod("GET");
+    request.setServletPath("/blockers");
+
+    var response = new MockHttpServletResponse();
+
+    // When
+    sut.doFilter(request, response, chain);
+
+    // Then
+    assertThat(response.getStatus()).isEqualTo(HttpStatus.OK.value());
+  }
+}


### PR DESCRIPTION
## PR 개요
“Blocker(차단기)” 기능의 도메인 모델부터 필터, 초기화, REST API, 테스트, 고정 확장자 차단기 생성까지 완료한 작업입니다.

---


## 주요 변경사항

### 1. 도메인 모델 & 유효성
- `Blocker` 엔티티 추가  
  - 확장자(extension) 길이 및 포맷 검증 제약조건  
- `Type` enum 도입 (FIXED vs CUSTOM)  
- `CreateBlockerRequest` DTO로 입력 구조 개선  

### 2. 생성 · 조회 · 삭제 로직
- 서비스/인프라 계층에 Blocker CRUD 구현  
- soft-delete(`enabled=false`) 처리 및 재생성 로직  

### 3. 고정 확장자(FIXED) 초기화
- `ApplicationRunner` 이용해 서버 시작 시 FIXED 확장자 자동 등록  

### 4. 업로드 필터링
- `ExtensionBlockerFilter` (`OncePerRequestFilter` 기반)  
  - 허용되지 않은 확장자 파일 업로드 차단  

---

## 테스트 커버리지 77%

### 유닛 테스트
- 서비스 레벨: 생성·조회·삭제 로직 검증  
- JPA 리포지토리: soft-delete 제외 조회 조건  
- 확장자 필터: 허용/차단 동작  
- `ApplicationRunner`: FIXED 초기화 동작  

### HTTP 통합 테스트
- REST API: 생성·조회·삭제 엔드포인트 검증  
- 초기화 시퀀스 및 재생성 시나리오 검증  

---

## 리팩토링 & 기타
- 패키지 구조 정리 (`persistence` 패키지 분리)  
- 엔드포인트 명 → 복수형으로 통일  
- 확장자 길이 검증 한도 10→20으로 상향  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced endpoints to manage file extension blockers, including creating, listing, and deleting blocked extensions.
  * Added validation to ensure file extensions are 1-20 alphanumeric characters.
  * Implemented a filter to block file uploads with restricted extensions, returning an error if blocked.
  * Preloaded a set of fixed extensions to be blocked by default.
  * Provided endpoints for file uploads with extension validation.

* **Bug Fixes**
  * Not applicable.

* **Tests**
  * Added comprehensive tests for extension validation, blocker creation/deletion, repository behavior, fixed extension initialization, and filter logic.

* **Documentation**
  * Added example HTTP requests for extension blocker management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->